### PR TITLE
Add persistent total stats tracking and UI

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -38,6 +38,7 @@
       </div>
     </div>
     <script src="./js/shared.js"></script>
+    <script src="./js/stats.js"></script>
     <script src="./js/ui-audio.js"></script>
     <script src="./js/single-player.js"></script>
     <script src="./js/versus.js"></script>

--- a/web/js/game.js
+++ b/web/js/game.js
@@ -515,8 +515,220 @@ class UIManager {
       </div>
     `;
   }
-  showGameOver({ score, level, onRetry, onMenu }) {
+
+  showTotalStats({ totals, onClose } = {}) {
     this.resetOverlayState();
+    const sanitizeValue = (value) => {
+      const number = Number(value);
+      if (!Number.isFinite(number)) return 0;
+      return Math.max(0, Math.floor(number));
+    };
+    const defaultTotals = {
+      enemiesDestroyed: 0,
+      asteroidsSmashed: 0,
+      bossesKilled: 0,
+      deathCount: 0,
+      playtimeSeconds: 0,
+    };
+    const sanitizeTotals = (value) => {
+      if (!value || typeof value !== 'object') {
+        return { ...defaultTotals };
+      }
+      return {
+        enemiesDestroyed: sanitizeValue(value.enemiesDestroyed),
+        asteroidsSmashed: sanitizeValue(value.asteroidsSmashed),
+        bossesKilled: sanitizeValue(value.bossesKilled),
+        deathCount: sanitizeValue(value.deathCount),
+        playtimeSeconds: sanitizeValue(value.playtimeSeconds),
+      };
+    };
+
+    let resolvedTotals = totals && typeof totals === 'object' ? sanitizeTotals(totals) : null;
+    if (!resolvedTotals) {
+      if (SpaceVoid.stats && typeof SpaceVoid.stats.getTotals === 'function') {
+        resolvedTotals = sanitizeTotals(SpaceVoid.stats.getTotals());
+      } else if (SpaceVoid.stats && SpaceVoid.stats.DEFAULT_TOTALS) {
+        resolvedTotals = sanitizeTotals(SpaceVoid.stats.DEFAULT_TOTALS);
+      } else {
+        resolvedTotals = { ...defaultTotals };
+      }
+    }
+
+    const formatPlaytime =
+      SpaceVoid.stats && typeof SpaceVoid.stats.formatPlaytime === 'function'
+        ? SpaceVoid.stats.formatPlaytime
+        : (seconds) => {
+            const safeSeconds = sanitizeValue(seconds);
+            const mins = Math.floor(safeSeconds / 60);
+            const secs = safeSeconds % 60;
+            return `${mins}m ${secs}s`;
+          };
+
+    this.overlay.style.display = 'flex';
+    this.overlay.style.flexDirection = 'column';
+    this.overlay.style.alignItems = 'center';
+    this.overlay.style.justifyContent = 'center';
+    this.overlay.innerHTML = `
+      <div class="menu menu--modal glass-panel" role="dialog" aria-labelledby="total-stats-title">
+        <div class="menu__header">
+          <h1 class="menu__title" id="total-stats-title">Total Stats</h1>
+          <p class="menu__subtitle menu__subtitle--muted">Lifetime performance across all missions.</p>
+        </div>
+        <div class="menu__stats menu__stats--wide">
+          <div class="menu__stat">
+            <span class="menu__stat-label">Total Enemies Destroyed</span>
+            <span class="menu__stat-value">${resolvedTotals.enemiesDestroyed}</span>
+          </div>
+          <div class="menu__stat">
+            <span class="menu__stat-label">Total Asteroids Smashed</span>
+            <span class="menu__stat-value">${resolvedTotals.asteroidsSmashed}</span>
+          </div>
+          <div class="menu__stat">
+            <span class="menu__stat-label">Total Bosses Defeated</span>
+            <span class="menu__stat-value">${resolvedTotals.bossesKilled}</span>
+          </div>
+          <div class="menu__stat">
+            <span class="menu__stat-label">Total Deaths</span>
+            <span class="menu__stat-value">${resolvedTotals.deathCount}</span>
+          </div>
+          <div class="menu__stat menu__stat--full">
+            <span class="menu__stat-label">Total Playtime</span>
+            <span class="menu__stat-value">${formatPlaytime(resolvedTotals.playtimeSeconds)}</span>
+          </div>
+        </div>
+        <div class="menu__actions menu__actions--modal">
+          <button class="menu__button glass-button glass-button--secondary" data-action="close" data-ui-sound="button">${
+            onClose ? 'Back' : 'Close'
+          }</button>
+        </div>
+      </div>
+    `;
+
+    const buttons = Array.from(this.overlay.querySelectorAll('button[data-action]'));
+    let focusedIndex = buttons.length ? 0 : -1;
+
+    const focusListeners = buttons.map((button, index) => {
+      const listener = () => {
+        focusedIndex = index;
+      };
+      button.addEventListener('focus', listener);
+      return listener;
+    });
+
+    const focusButton = (index) => {
+      if (!buttons.length) return;
+      const safeIndex = (index + buttons.length) % buttons.length;
+      const target = buttons[safeIndex];
+      if (!target) return;
+      focusedIndex = safeIndex;
+      target.focus({ preventScroll: true });
+    };
+
+    if (buttons.length) {
+      window.requestAnimationFrame(() => {
+        focusButton(focusedIndex);
+      });
+    }
+
+    const keyHandler = (event) => {
+      if (!buttons.length) return;
+      const { key } = event;
+      if (key === 'ArrowDown' || key === 'ArrowRight' || key === 'ArrowUp' || key === 'ArrowLeft') {
+        event.preventDefault();
+        focusButton(focusedIndex + (key === 'ArrowDown' || key === 'ArrowRight' ? 1 : -1));
+      } else if (key === 'Home') {
+        event.preventDefault();
+        focusButton(0);
+      } else if (key === 'End') {
+        event.preventDefault();
+        focusButton(buttons.length - 1);
+      } else if (key === 'Enter' || key === ' ' || key === 'Space' || key === 'Spacebar') {
+        const activeElement = document.activeElement;
+        if (activeElement instanceof HTMLElement && buttons.includes(activeElement)) {
+          event.preventDefault();
+          activeElement.click();
+        }
+      }
+    };
+
+    this.overlay.addEventListener('keydown', keyHandler);
+
+    const handler = (event) => {
+      if (!(event.target instanceof HTMLElement)) return;
+      const button = event.target.closest('button[data-action="close"]');
+      if (!button) return;
+      if (SpaceVoid.uiAudio && typeof SpaceVoid.uiAudio.play === 'function') {
+        SpaceVoid.uiAudio.play('cancel');
+      }
+      cleanup();
+      if (typeof onClose === 'function') {
+        onClose();
+      } else if (typeof this.hideOverlay === 'function') {
+        this.hideOverlay();
+      } else {
+        this.overlay.style.display = 'none';
+      }
+    };
+
+    const cleanup = () => {
+      this.overlay.removeEventListener('click', handler);
+      this.overlay.removeEventListener('keydown', keyHandler);
+      buttons.forEach((button, index) => {
+        button.removeEventListener('focus', focusListeners[index]);
+      });
+    };
+
+    this.overlay.addEventListener('click', handler);
+    this.currentHandler = cleanup;
+  }
+  showGameOver({ score, level, stats = {}, totals = null, onRetry, onMenu }) {
+    this.resetOverlayState();
+    const sanitizeValue = (value) => {
+      const number = Number(value);
+      if (!Number.isFinite(number)) return 0;
+      return Math.max(0, Math.floor(number));
+    };
+    const sanitizedStats = {
+      enemiesDestroyed: sanitizeValue(stats.enemiesDestroyed),
+      asteroidsSmashed: sanitizeValue(stats.asteroidsSmashed),
+      bossesKilled: sanitizeValue(stats.bossesKilled),
+      deaths: sanitizeValue(stats.deaths),
+      playtimeSeconds: sanitizeValue(stats.playtimeSeconds),
+    };
+    const baseTotals = {
+      enemiesDestroyed: 0,
+      asteroidsSmashed: 0,
+      bossesKilled: 0,
+      deathCount: 0,
+      playtimeSeconds: 0,
+    };
+    const sanitizeTotals = (value) => {
+      if (!value || typeof value !== 'object') return null;
+      return {
+        enemiesDestroyed: sanitizeValue(value.enemiesDestroyed),
+        asteroidsSmashed: sanitizeValue(value.asteroidsSmashed),
+        bossesKilled: sanitizeValue(value.bossesKilled),
+        deathCount: sanitizeValue(value.deathCount),
+        playtimeSeconds: sanitizeValue(value.playtimeSeconds),
+      };
+    };
+    const totalsFromArgs = sanitizeTotals(totals);
+    const getTotalsForView = () => {
+      if (totalsFromArgs) {
+        return { ...baseTotals, ...totalsFromArgs };
+      }
+      if (SpaceVoid.stats && typeof SpaceVoid.stats.getTotals === 'function') {
+        const loaded = sanitizeTotals(SpaceVoid.stats.getTotals());
+        if (loaded) {
+          return { ...baseTotals, ...loaded };
+        }
+      }
+      if (SpaceVoid.stats && SpaceVoid.stats.DEFAULT_TOTALS) {
+        return { ...baseTotals, ...SpaceVoid.stats.DEFAULT_TOTALS };
+      }
+      return { ...baseTotals };
+    };
+
     this.overlay.style.display = 'flex';
     this.overlay.style.flexDirection = 'column';
     this.overlay.style.alignItems = 'center';
@@ -536,10 +748,19 @@ class UIManager {
             <span class="menu__stat-label">Level</span>
             <span class="menu__stat-value">${level}</span>
           </div>
+          <div class="menu__stat">
+            <span class="menu__stat-label">Enemies Destroyed</span>
+            <span class="menu__stat-value">${sanitizedStats.enemiesDestroyed}</span>
+          </div>
+          <div class="menu__stat">
+            <span class="menu__stat-label">Asteroids Smashed</span>
+            <span class="menu__stat-value">${sanitizedStats.asteroidsSmashed}</span>
+          </div>
         </div>
         <div class="menu__actions menu__actions--modal">
           <button class="menu__button glass-button glass-button--primary" data-action="retry" data-ui-sound="button">Retry Mission</button>
           <button class="menu__button glass-button glass-button--secondary" data-action="menu" data-ui-sound="button">Main Menu</button>
+          <button class="menu__button glass-button glass-button--secondary" data-action="totals" data-ui-sound="button">Total Stats</button>
         </div>
       </div>
     `;
@@ -602,6 +823,26 @@ class UIManager {
       const button = event.target.closest('button[data-action]');
       if (!button) return;
       const action = button.dataset.action;
+      if (action === 'totals') {
+        if (SpaceVoid.uiAudio && typeof SpaceVoid.uiAudio.play === 'function') {
+          SpaceVoid.uiAudio.play('button');
+        }
+        const totalsForView = getTotalsForView();
+        this.showTotalStats({
+          totals: totalsForView,
+          onClose: () => {
+            this.showGameOver({
+              score,
+              level,
+              stats: sanitizedStats,
+              totals: totalsForView,
+              onRetry,
+              onMenu,
+            });
+          },
+        });
+        return;
+      }
       if (SpaceVoid.uiAudio && typeof SpaceVoid.uiAudio.play === 'function') {
         if (action === 'menu') {
           SpaceVoid.uiAudio.play('cancel');
@@ -948,11 +1189,13 @@ function startGame(mode) {
     currentWorld = factory({
       assets,
       input,
-      onGameOver: ({ score, level }) => {
+      onGameOver: ({ score, level, stats, totals }) => {
         currentState = GAME_STATE.GAME_OVER;
         ui.showGameOver({
           score: Math.floor(score),
           level,
+          stats,
+          totals,
           onRetry: () => startGame(mode),
           onMenu: showMainMenu,
         });

--- a/web/js/game.js
+++ b/web/js/game.js
@@ -569,9 +569,9 @@ class UIManager {
     this.overlay.style.alignItems = 'center';
     this.overlay.style.justifyContent = 'center';
     this.overlay.innerHTML = `
-      <div class="menu menu--modal glass-panel" role="dialog" aria-labelledby="total-stats-title">
+      <div class="menu menu--modal menu--compact glass-panel" role="dialog" aria-labelledby="stats-title">
         <div class="menu__header">
-          <h1 class="menu__title" id="total-stats-title">Total Stats</h1>
+          <h1 class="menu__title" id="stats-title">Stats</h1>
           <p class="menu__subtitle menu__subtitle--muted">Lifetime performance across all missions.</p>
         </div>
         <div class="menu__stats menu__stats--wide">
@@ -734,7 +734,7 @@ class UIManager {
     this.overlay.style.alignItems = 'center';
     this.overlay.style.justifyContent = 'center';
     this.overlay.innerHTML = `
-      <div class="menu menu--modal glass-panel" role="dialog" aria-labelledby="game-over-title">
+      <div class="menu menu--modal menu--compact glass-panel" role="dialog" aria-labelledby="game-over-title">
         <div class="menu__header">
           <h1 class="menu__title" id="game-over-title">Game Over</h1>
           <p class="menu__subtitle menu__subtitle--muted">Mission failed, but data was recovered.</p>
@@ -760,7 +760,7 @@ class UIManager {
         <div class="menu__actions menu__actions--modal">
           <button class="menu__button glass-button glass-button--primary" data-action="retry" data-ui-sound="button">Retry Mission</button>
           <button class="menu__button glass-button glass-button--secondary" data-action="menu" data-ui-sound="button">Main Menu</button>
-          <button class="menu__button glass-button glass-button--secondary" data-action="totals" data-ui-sound="button">Total Stats</button>
+          <button class="menu__button glass-button glass-button--secondary" data-action="totals" data-ui-sound="button">Stats</button>
         </div>
       </div>
     `;

--- a/web/js/menu.js
+++ b/web/js/menu.js
@@ -179,15 +179,15 @@
             ${resumeButton}
             <div class="menu__actions">
               <button class="menu__button glass-button glass-button--primary menu__button--stacked" data-action="single" data-ui-sound="button">
-                <span class="menu__button-title">Single Player</span>
+                <span class="menu__button-title">SINGLE PLAYER</span>
                 <span class="menu__button-meta">Solo arcade campaign</span>
               </button>
               <button class="menu__button glass-button glass-button--primary menu__button--stacked" data-action="coop" data-ui-sound="button">
-                <span class="menu__button-title">Co-op Mode</span>
+                <span class="menu__button-title">CO-OP MODE</span>
                 <span class="menu__button-meta">Team up on one screen</span>
               </button>
               <button class="menu__button glass-button glass-button--primary menu__button--stacked" data-action="versus" data-ui-sound="button">
-                <span class="menu__button-title">Versus Mode</span>
+                <span class="menu__button-title">VS MODE</span>
                 <span class="menu__button-meta">Duel for galactic glory</span>
               </button>
             </div>

--- a/web/js/menu.js
+++ b/web/js/menu.js
@@ -193,6 +193,7 @@
             </div>
             <div class="menu__footer">
               <button class="menu__button glass-button glass-button--secondary" data-action="settings" data-ui-sound="button">Settings</button>
+              <button class="menu__button glass-button glass-button--secondary" data-action="totals" data-ui-sound="button">Total Stats</button>
             </div>
           </div>
         </div>
@@ -274,6 +275,16 @@
 
       overlay.addEventListener('keydown', keyHandler);
 
+      const reopenMenu = () => {
+        ui.showMenu({
+          onStartSingle,
+          onStartCoop,
+          onStartVersus,
+          onSettings,
+          onResume,
+        });
+      };
+
       const handler = (event) => {
         if (!(event.target instanceof HTMLElement)) return;
 
@@ -293,6 +304,12 @@
             break;
           case 'settings':
             onSettings();
+            break;
+          case 'totals':
+            if (SpaceVoid.uiAudio && typeof SpaceVoid.uiAudio.play === 'function') {
+              SpaceVoid.uiAudio.play('button');
+            }
+            ui.showTotalStats({ onClose: reopenMenu });
             break;
           case 'resume':
             if (onResume) {

--- a/web/js/menu.js
+++ b/web/js/menu.js
@@ -193,7 +193,7 @@
             </div>
             <div class="menu__footer">
               <button class="menu__button glass-button glass-button--secondary" data-action="settings" data-ui-sound="button">Settings</button>
-              <button class="menu__button glass-button glass-button--secondary" data-action="totals" data-ui-sound="button">Total Stats</button>
+              <button class="menu__button glass-button glass-button--secondary" data-action="totals" data-ui-sound="button">Stats</button>
             </div>
           </div>
         </div>

--- a/web/js/single-player.js
+++ b/web/js/single-player.js
@@ -931,7 +931,7 @@ class GameWorld {
           left: 'ArrowLeft',
           right: 'ArrowRight',
           shoot: 'Enter',
-          rocket: 'Enter',
+          rocket: 'Numpad0',
           speed: 'Numpad0',
         },
         facingLeft: false,

--- a/web/js/single-player.js
+++ b/web/js/single-player.js
@@ -878,6 +878,15 @@ class GameWorld {
     this.cooperative = mode === 'coop';
     this.paused = false;
     this.state = GAME_STATE.GAME;
+    this.sessionStartTime = Date.now();
+    this.sessionStats = {
+      enemiesDestroyed: 0,
+      asteroidsSmashed: 0,
+      bossesKilled: 0,
+      deaths: 0,
+      playtimeSeconds: 0,
+    };
+    this.sessionFinalized = false;
     this.music = this.assets.background_music;
     this.music.loop = true;
     this.music.volume = 0.4;
@@ -931,6 +940,37 @@ class GameWorld {
       player2.reset({ x: 100, y: HEIGHT / 3 - player2.height / 2 });
       this.players.push(player2);
     }
+  }
+
+  recordEnemyDestroyed(amount = 1) {
+    const increment = Number.isFinite(amount) ? Math.max(0, Math.floor(amount)) : 0;
+    this.sessionStats.enemiesDestroyed += increment;
+  }
+
+  recordAsteroidSmashed(amount = 1) {
+    const increment = Number.isFinite(amount) ? Math.max(0, Math.floor(amount)) : 0;
+    this.sessionStats.asteroidsSmashed += increment;
+  }
+
+  recordBossKilled(amount = 1) {
+    const increment = Number.isFinite(amount) ? Math.max(0, Math.floor(amount)) : 0;
+    this.sessionStats.bossesKilled += increment;
+  }
+
+  recordPlayerDeath(amount = 1) {
+    const increment = Number.isFinite(amount) ? Math.max(0, Math.floor(amount)) : 0;
+    this.sessionStats.deaths += increment;
+  }
+
+  finalizeSessionStats() {
+    if (!this.sessionFinalized) {
+      const elapsedMs = Date.now() - this.sessionStartTime;
+      if (Number.isFinite(elapsedMs) && elapsedMs > 0) {
+        this.sessionStats.playtimeSeconds += Math.floor(elapsedMs / 1000);
+      }
+      this.sessionFinalized = true;
+    }
+    return { ...this.sessionStats };
   }
 
   spawnEnemy() {
@@ -1060,6 +1100,7 @@ class GameWorld {
             enemy.dead = true;
             this.createExplosion(enemyBounds);
             this.score += 10;
+            this.recordEnemyDestroyed();
           }
         }
       });
@@ -1078,6 +1119,7 @@ class GameWorld {
         asteroid.dead = true;
         this.createExplosion(bounds);
         this.score += 5;
+        this.recordAsteroidSmashed();
         asteroid.breakApart().forEach((piece) => this.asteroids.push(piece));
         break;
       }
@@ -1118,6 +1160,7 @@ class GameWorld {
             enemy.dead = true;
             this.createExplosion(enemy.getBounds());
             this.score += 20;
+            this.recordEnemyDestroyed();
           }
         }
       });
@@ -1128,6 +1171,7 @@ class GameWorld {
           asteroid.dead = true;
           this.createExplosion(asteroid.getBounds());
           this.score += 10;
+          this.recordAsteroidSmashed();
         }
       });
     });
@@ -1142,6 +1186,7 @@ class GameWorld {
         if (intersects(bounds, bullet.getBounds())) {
           bullet.dead = true;
           player.alive = false;
+          this.recordPlayerDeath();
           this.createExplosion(bounds);
           this.assets.explosion_sound.currentTime = 0;
           this.assets.explosion_sound.play();
@@ -1161,8 +1206,10 @@ class GameWorld {
             this.defeatBoss(enemy);
           } else {
             enemy.dead = true;
+            this.recordEnemyDestroyed();
           }
           player.alive = false;
+          this.recordPlayerDeath();
           this.createExplosion(bounds);
           this.assets.explosion_sound.currentTime = 0;
           this.assets.explosion_sound.play();
@@ -1180,6 +1227,8 @@ class GameWorld {
         if (intersects(bounds, asteroid.getBounds())) {
           asteroid.dead = true;
           player.alive = false;
+          this.recordAsteroidSmashed();
+          this.recordPlayerDeath();
           this.createExplosion(bounds);
           this.assets.explosion_sound.currentTime = 0;
           this.assets.explosion_sound.play();
@@ -1214,12 +1263,14 @@ class GameWorld {
         if (!enemy.dead) {
           enemy.dead = true;
           this.createExplosion(enemy.getBounds());
+          this.recordEnemyDestroyed();
         }
       });
       this.asteroids.forEach((asteroid) => {
         if (!asteroid.dead) {
           asteroid.dead = true;
           this.createExplosion(asteroid.getBounds());
+          this.recordAsteroidSmashed();
         }
       });
       this.assets.explosion_sound.currentTime = 0;
@@ -1257,6 +1308,7 @@ class GameWorld {
     boss.dead = true;
     this.createExplosion(boss.getBounds());
     this.score += 50;
+    this.recordBossKilled();
     this.level += 1;
     this.nextBossScore += this.level * 100;
     this.enemySpawnInterval = Math.max(0.5, this.enemySpawnInterval - 0.2);
@@ -1282,8 +1334,18 @@ class GameWorld {
 
   finishGame() {
     this.state = GAME_STATE.GAME_OVER;
+    const sessionStats = this.finalizeSessionStats();
+    let totalStats = null;
+    if (SpaceVoid.stats && typeof SpaceVoid.stats.recordSession === 'function') {
+      totalStats = SpaceVoid.stats.recordSession(sessionStats);
+    }
     if (this.onGameOver) {
-      this.onGameOver({ score: this.score, level: this.level });
+      this.onGameOver({
+        score: this.score,
+        level: this.level,
+        stats: sessionStats,
+        totals: totalStats,
+      });
     }
   }
 

--- a/web/js/stats.js
+++ b/web/js/stats.js
@@ -1,0 +1,105 @@
+(function (global) {
+  const SpaceVoid = (global.SpaceVoid = global.SpaceVoid || {});
+
+  const STORAGE_KEY = 'space-void-total-stats';
+  const DEFAULT_TOTALS = {
+    enemiesDestroyed: 0,
+    asteroidsSmashed: 0,
+    bossesKilled: 0,
+    deathCount: 0,
+    playtimeSeconds: 0,
+  };
+
+  function cloneDefaults() {
+    return { ...DEFAULT_TOTALS };
+  }
+
+  function sanitizeNumber(value) {
+    if (typeof value !== 'number' || Number.isNaN(value) || !Number.isFinite(value)) {
+      return 0;
+    }
+    return Math.max(0, Math.floor(value));
+  }
+
+  function sanitizeTotals(rawTotals) {
+    if (!rawTotals || typeof rawTotals !== 'object') {
+      return cloneDefaults();
+    }
+    const totals = cloneDefaults();
+    totals.enemiesDestroyed = sanitizeNumber(rawTotals.enemiesDestroyed);
+    totals.asteroidsSmashed = sanitizeNumber(rawTotals.asteroidsSmashed);
+    totals.bossesKilled = sanitizeNumber(rawTotals.bossesKilled);
+    totals.deathCount = sanitizeNumber(rawTotals.deathCount);
+    totals.playtimeSeconds = sanitizeNumber(rawTotals.playtimeSeconds);
+    return totals;
+  }
+
+  function loadTotals() {
+    if (!('localStorage' in global) || !global.localStorage) {
+      return cloneDefaults();
+    }
+    try {
+      const stored = global.localStorage.getItem(STORAGE_KEY);
+      if (!stored) {
+        return cloneDefaults();
+      }
+      const parsed = JSON.parse(stored);
+      return sanitizeTotals(parsed);
+    } catch (error) {
+      console.warn('Failed to load total stats from localStorage.', error);
+      return cloneDefaults();
+    }
+  }
+
+  function saveTotals(totals) {
+    if (!('localStorage' in global) || !global.localStorage) {
+      return;
+    }
+    try {
+      global.localStorage.setItem(STORAGE_KEY, JSON.stringify(totals));
+    } catch (error) {
+      console.warn('Failed to save total stats to localStorage.', error);
+    }
+  }
+
+  function recordSession(sessionStats = {}) {
+    const totals = loadTotals();
+    const updateNumber = (value) => (typeof value === 'number' && Number.isFinite(value) ? value : 0);
+
+    totals.enemiesDestroyed += updateNumber(sessionStats.enemiesDestroyed);
+    totals.asteroidsSmashed += updateNumber(sessionStats.asteroidsSmashed);
+    totals.bossesKilled += updateNumber(sessionStats.bossesKilled);
+    totals.deathCount += updateNumber(sessionStats.deaths);
+    totals.playtimeSeconds += Math.max(0, Math.floor(updateNumber(sessionStats.playtimeSeconds)));
+
+    saveTotals(totals);
+    return { ...totals };
+  }
+
+  function getTotals() {
+    return loadTotals();
+  }
+
+  function formatPlaytime(seconds) {
+    const totalSeconds = Math.max(0, Math.floor(typeof seconds === 'number' ? seconds : 0));
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const secs = totalSeconds % 60;
+    const segments = [];
+    if (hours > 0) {
+      segments.push(`${hours}h`);
+    }
+    if (minutes > 0 || hours > 0) {
+      segments.push(`${minutes}m`);
+    }
+    segments.push(`${secs}s`);
+    return segments.join(' ');
+  }
+
+  SpaceVoid.stats = {
+    getTotals,
+    recordSession,
+    formatPlaytime,
+    DEFAULT_TOTALS: cloneDefaults(),
+  };
+})(window);

--- a/web/js/ui-audio.js
+++ b/web/js/ui-audio.js
@@ -43,12 +43,12 @@
     masterGain.gain.value = currentVolume * BASE_GAIN;
 
     effectInput = context.createGain();
-    effectInput.gain.value = 0.85;
+    effectInput.gain.value = 0.42;
 
     filterNode = context.createBiquadFilter();
     filterNode.type = 'lowpass';
-    filterNode.frequency.value = 2300;
-    filterNode.Q.value = 0.7;
+    filterNode.frequency.value = 1600;
+    filterNode.Q.value = 0.6;
 
     compressor = context.createDynamicsCompressor();
     compressor.threshold.value = -18;
@@ -58,13 +58,13 @@
     compressor.release.value = 0.1;
 
     delayNode = context.createDelay(MAX_DELAY_TIME);
-    delayNode.delayTime.value = 0.09;
+    delayNode.delayTime.value = 0.07;
 
     delayFeedback = context.createGain();
-    delayFeedback.gain.value = 0.12;
+    delayFeedback.gain.value = 0.1;
 
     delayWet = context.createGain();
-    delayWet.gain.value = 0.18;
+    delayWet.gain.value = 0.14;
 
     effectInput.connect(filterNode);
     filterNode.connect(compressor);
@@ -133,15 +133,15 @@
     const osc = ctx.createOscillator();
     const gain = ctx.createGain();
 
-    osc.type = 'triangle';
-    osc.frequency.setValueAtTime(600, now);
-    osc.frequency.exponentialRampToValueAtTime(880, now + 0.16);
+    osc.type = 'sine';
+    osc.frequency.setValueAtTime(420, now);
+    osc.frequency.exponentialRampToValueAtTime(620, now + 0.16);
 
     const stopTime = scheduleGainEnvelope(gain, now, {
-      attack: 0.01,
-      decay: 0.05,
-      sustain: 0.22,
-      release: 0.08,
+      attack: 0.012,
+      decay: 0.06,
+      sustain: 0.18,
+      release: 0.1,
       duration: 0.16,
     });
 
@@ -161,14 +161,14 @@
     const gain = ctx.createGain();
 
     osc.type = 'sine';
-    osc.frequency.setValueAtTime(420, now);
-    osc.frequency.linearRampToValueAtTime(620, now + 0.07);
+    osc.frequency.setValueAtTime(360, now);
+    osc.frequency.linearRampToValueAtTime(520, now + 0.07);
 
     const stopTime = scheduleGainEnvelope(gain, now, {
-      attack: 0.003,
-      decay: 0.05,
-      sustain: 0.24,
-      release: 0.08,
+      attack: 0.004,
+      decay: 0.06,
+      sustain: 0.2,
+      release: 0.1,
       duration: 0.14,
     });
 
@@ -188,21 +188,21 @@
     gain.connect(effectInput);
 
     const oscA = ctx.createOscillator();
-    oscA.type = 'triangle';
-    oscA.frequency.setValueAtTime(520, now);
-    oscA.frequency.linearRampToValueAtTime(700, now + 0.12);
+    oscA.type = 'sine';
+    oscA.frequency.setValueAtTime(420, now);
+    oscA.frequency.linearRampToValueAtTime(600, now + 0.12);
 
     const oscB = ctx.createOscillator();
     oscB.type = 'sine';
     const secondStart = now + 0.08;
-    oscB.frequency.setValueAtTime(720, secondStart);
-    oscB.frequency.linearRampToValueAtTime(940, secondStart + 0.12);
+    oscB.frequency.setValueAtTime(560, secondStart);
+    oscB.frequency.linearRampToValueAtTime(760, secondStart + 0.12);
 
     const stopTime = scheduleGainEnvelope(gain, now, {
-      attack: 0.006,
-      decay: 0.07,
-      sustain: 0.3,
-      release: 0.16,
+      attack: 0.008,
+      decay: 0.08,
+      sustain: 0.26,
+      release: 0.18,
       duration: 0.24,
     });
 
@@ -226,15 +226,15 @@
     const osc = ctx.createOscillator();
     const gain = ctx.createGain();
 
-    osc.type = 'triangle';
-    osc.frequency.setValueAtTime(260, now);
-    osc.frequency.linearRampToValueAtTime(150, now + 0.2);
+    osc.type = 'sine';
+    osc.frequency.setValueAtTime(220, now);
+    osc.frequency.linearRampToValueAtTime(140, now + 0.2);
 
     const stopTime = scheduleGainEnvelope(gain, now, {
-      attack: 0.012,
+      attack: 0.014,
       decay: 0.1,
-      sustain: 0.18,
-      release: 0.16,
+      sustain: 0.16,
+      release: 0.18,
       duration: 0.22,
     });
 
@@ -254,17 +254,17 @@
     const osc = ctx.createOscillator();
     const gain = ctx.createGain();
 
-    osc.type = 'triangle';
-    const startFreq = rising ? 480 : 360;
-    const endFreq = rising ? 720 : 240;
+    osc.type = 'sine';
+    const startFreq = rising ? 380 : 300;
+    const endFreq = rising ? 560 : 220;
     osc.frequency.setValueAtTime(startFreq, now);
     osc.frequency.linearRampToValueAtTime(endFreq, now + 0.15);
 
     const stopTime = scheduleGainEnvelope(gain, now, {
-      attack: 0.005,
-      decay: 0.07,
-      sustain: 0.22,
-      release: 0.16,
+      attack: 0.006,
+      decay: 0.08,
+      sustain: 0.2,
+      release: 0.18,
       duration: 0.18,
     });
 
@@ -286,8 +286,8 @@
 
     source.buffer = getNoiseBuffer();
     filter.type = 'bandpass';
-    filter.frequency.value = 180;
-    filter.Q.value = 6;
+    filter.frequency.value = 150;
+    filter.Q.value = 5;
 
     const stopTime = scheduleGainEnvelope(gain, now, {
       attack: 0.003,
@@ -316,14 +316,14 @@
     const gain = ctx.createGain();
 
     osc.type = 'sine';
-    osc.frequency.setValueAtTime(540, now);
-    osc.frequency.linearRampToValueAtTime(620, now + 0.05);
+    osc.frequency.setValueAtTime(420, now);
+    osc.frequency.linearRampToValueAtTime(500, now + 0.05);
 
     const stopTime = scheduleGainEnvelope(gain, now, {
-      attack: 0.002,
-      decay: 0.03,
-      sustain: 0.18,
-      release: 0.07,
+      attack: 0.003,
+      decay: 0.04,
+      sustain: 0.16,
+      release: 0.08,
       duration: 0.08,
     });
 

--- a/web/js/ui-audio.js
+++ b/web/js/ui-audio.js
@@ -17,7 +17,7 @@
     return;
   }
 
-  const BASE_GAIN = 0.55;
+  const BASE_GAIN = 0.3;
   const MAX_DELAY_TIME = 0.4;
   const HOVER_DEBOUNCE_MS = 120;
   const ADJUST_DEBOUNCE_MS = 140;
@@ -43,28 +43,28 @@
     masterGain.gain.value = currentVolume * BASE_GAIN;
 
     effectInput = context.createGain();
-    effectInput.gain.value = 0.42;
+    effectInput.gain.value = 0.26;
 
     filterNode = context.createBiquadFilter();
     filterNode.type = 'lowpass';
-    filterNode.frequency.value = 1600;
-    filterNode.Q.value = 0.6;
+    filterNode.frequency.value = 1100;
+    filterNode.Q.value = 0.5;
 
     compressor = context.createDynamicsCompressor();
-    compressor.threshold.value = -18;
+    compressor.threshold.value = -22;
     compressor.knee.value = 18;
-    compressor.ratio.value = 4;
-    compressor.attack.value = 0.003;
-    compressor.release.value = 0.1;
+    compressor.ratio.value = 3;
+    compressor.attack.value = 0.006;
+    compressor.release.value = 0.18;
 
     delayNode = context.createDelay(MAX_DELAY_TIME);
-    delayNode.delayTime.value = 0.07;
+    delayNode.delayTime.value = 0.05;
 
     delayFeedback = context.createGain();
-    delayFeedback.gain.value = 0.1;
+    delayFeedback.gain.value = 0.06;
 
     delayWet = context.createGain();
-    delayWet.gain.value = 0.14;
+    delayWet.gain.value = 0.08;
 
     effectInput.connect(filterNode);
     filterNode.connect(compressor);
@@ -134,15 +134,15 @@
     const gain = ctx.createGain();
 
     osc.type = 'sine';
-    osc.frequency.setValueAtTime(420, now);
-    osc.frequency.exponentialRampToValueAtTime(620, now + 0.16);
+    osc.frequency.setValueAtTime(260, now);
+    osc.frequency.exponentialRampToValueAtTime(380, now + 0.18);
 
     const stopTime = scheduleGainEnvelope(gain, now, {
-      attack: 0.012,
-      decay: 0.06,
-      sustain: 0.18,
-      release: 0.1,
-      duration: 0.16,
+      attack: 0.02,
+      decay: 0.08,
+      sustain: 0.16,
+      release: 0.16,
+      duration: 0.2,
     });
 
     osc.connect(gain);
@@ -161,15 +161,15 @@
     const gain = ctx.createGain();
 
     osc.type = 'sine';
-    osc.frequency.setValueAtTime(360, now);
-    osc.frequency.linearRampToValueAtTime(520, now + 0.07);
+    osc.frequency.setValueAtTime(240, now);
+    osc.frequency.linearRampToValueAtTime(360, now + 0.1);
 
     const stopTime = scheduleGainEnvelope(gain, now, {
-      attack: 0.004,
-      decay: 0.06,
-      sustain: 0.2,
-      release: 0.1,
-      duration: 0.14,
+      attack: 0.01,
+      decay: 0.08,
+      sustain: 0.18,
+      release: 0.14,
+      duration: 0.18,
     });
 
     osc.connect(gain);
@@ -189,21 +189,21 @@
 
     const oscA = ctx.createOscillator();
     oscA.type = 'sine';
-    oscA.frequency.setValueAtTime(420, now);
-    oscA.frequency.linearRampToValueAtTime(600, now + 0.12);
+    oscA.frequency.setValueAtTime(320, now);
+    oscA.frequency.linearRampToValueAtTime(480, now + 0.16);
 
     const oscB = ctx.createOscillator();
     oscB.type = 'sine';
     const secondStart = now + 0.08;
-    oscB.frequency.setValueAtTime(560, secondStart);
-    oscB.frequency.linearRampToValueAtTime(760, secondStart + 0.12);
+    oscB.frequency.setValueAtTime(420, secondStart);
+    oscB.frequency.linearRampToValueAtTime(600, secondStart + 0.16);
 
     const stopTime = scheduleGainEnvelope(gain, now, {
-      attack: 0.008,
-      decay: 0.08,
-      sustain: 0.26,
-      release: 0.18,
-      duration: 0.24,
+      attack: 0.012,
+      decay: 0.1,
+      sustain: 0.22,
+      release: 0.22,
+      duration: 0.28,
     });
 
     oscA.connect(gain);
@@ -227,15 +227,15 @@
     const gain = ctx.createGain();
 
     osc.type = 'sine';
-    osc.frequency.setValueAtTime(220, now);
-    osc.frequency.linearRampToValueAtTime(140, now + 0.2);
+    osc.frequency.setValueAtTime(160, now);
+    osc.frequency.linearRampToValueAtTime(120, now + 0.22);
 
     const stopTime = scheduleGainEnvelope(gain, now, {
-      attack: 0.014,
-      decay: 0.1,
-      sustain: 0.16,
-      release: 0.18,
-      duration: 0.22,
+      attack: 0.02,
+      decay: 0.12,
+      sustain: 0.14,
+      release: 0.22,
+      duration: 0.26,
     });
 
     osc.connect(gain);
@@ -255,17 +255,17 @@
     const gain = ctx.createGain();
 
     osc.type = 'sine';
-    const startFreq = rising ? 380 : 300;
-    const endFreq = rising ? 560 : 220;
+    const startFreq = rising ? 280 : 220;
+    const endFreq = rising ? 420 : 160;
     osc.frequency.setValueAtTime(startFreq, now);
     osc.frequency.linearRampToValueAtTime(endFreq, now + 0.15);
 
     const stopTime = scheduleGainEnvelope(gain, now, {
-      attack: 0.006,
-      decay: 0.08,
-      sustain: 0.2,
-      release: 0.18,
-      duration: 0.18,
+      attack: 0.012,
+      decay: 0.09,
+      sustain: 0.18,
+      release: 0.2,
+      duration: 0.22,
     });
 
     osc.connect(gain);
@@ -286,15 +286,15 @@
 
     source.buffer = getNoiseBuffer();
     filter.type = 'bandpass';
-    filter.frequency.value = 150;
-    filter.Q.value = 5;
+    filter.frequency.value = 110;
+    filter.Q.value = 4;
 
     const stopTime = scheduleGainEnvelope(gain, now, {
-      attack: 0.003,
-      decay: 0.04,
-      sustain: 0.18,
-      release: 0.1,
-      duration: 0.1,
+      attack: 0.006,
+      decay: 0.05,
+      sustain: 0.16,
+      release: 0.14,
+      duration: 0.12,
     });
 
     source.connect(filter);
@@ -316,15 +316,15 @@
     const gain = ctx.createGain();
 
     osc.type = 'sine';
-    osc.frequency.setValueAtTime(420, now);
-    osc.frequency.linearRampToValueAtTime(500, now + 0.05);
+    osc.frequency.setValueAtTime(300, now);
+    osc.frequency.linearRampToValueAtTime(360, now + 0.08);
 
     const stopTime = scheduleGainEnvelope(gain, now, {
-      attack: 0.003,
-      decay: 0.04,
-      sustain: 0.16,
-      release: 0.08,
-      duration: 0.08,
+      attack: 0.006,
+      decay: 0.05,
+      sustain: 0.14,
+      release: 0.12,
+      duration: 0.12,
     });
 
     osc.connect(gain);

--- a/web/styles.css
+++ b/web/styles.css
@@ -526,6 +526,7 @@ body {
 .menu__footer {
   display: flex;
   justify-content: center;
+  gap: clamp(12px, 3vw, 16px);
 }
 
 

--- a/web/styles.css
+++ b/web/styles.css
@@ -428,6 +428,60 @@ body {
   backdrop-filter: blur(22px);
 }
 
+.menu--compact {
+  width: min(320px, 92%);
+  padding: clamp(14px, 4vw, 22px);
+  gap: clamp(12px, 3vw, 18px);
+}
+
+.menu--compact .menu__header {
+  gap: 8px;
+}
+
+.menu--compact .menu__title {
+  font-size: clamp(1.2rem, 4vw, 1.8rem);
+  letter-spacing: 0.12em;
+}
+
+.menu--compact .menu__subtitle {
+  font-size: clamp(0.7rem, 1.8vw, 0.9rem);
+  letter-spacing: 0.24em;
+}
+
+.menu--compact .menu__subtitle--muted {
+  font-size: clamp(0.68rem, 1.6vw, 0.85rem);
+  letter-spacing: 0.18em;
+}
+
+.menu--compact .menu__stats {
+  gap: clamp(8px, 2.5vw, 12px);
+}
+
+.menu--compact .menu__stat {
+  min-width: 110px;
+  padding: clamp(8px, 2.5vw, 12px);
+  border-radius: 12px;
+}
+
+.menu--compact .menu__stat-label {
+  font-size: 0.6rem;
+  letter-spacing: 0.18em;
+}
+
+.menu--compact .menu__stat-value {
+  font-size: clamp(0.85rem, 2.4vw, 1.1rem);
+}
+
+.menu--compact .menu__actions {
+  gap: clamp(10px, 2.5vw, 14px);
+}
+
+.menu--compact .glass-button {
+  min-height: 42px;
+  padding: 10px 16px;
+  font-size: 0.85rem;
+}
+
 .menu__header {
   display: flex;
   flex-direction: column;

--- a/web/styles.css
+++ b/web/styles.css
@@ -419,7 +419,7 @@ body {
 
 .menu.menu--main.glass-panel {
   backdrop-filter: blur(5px);
-  border-radius: 150px;
+  border-radius: 26px;
 }
 
 .menu--modal {


### PR DESCRIPTION
## Summary
- add a stats helper that persists totals in localStorage and integrates with the shared GameWorld counters
- extend the game over screen and options flow with per-run metrics and a reusable Total Stats modal
- load the new stats module and adjust menu styling so the extra button lays out correctly

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_6905b767d5208330942eabb738d078f0